### PR TITLE
feat: Add history import and export functionality

### DIFF
--- a/background.js
+++ b/background.js
@@ -338,6 +338,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     sendResponse({ received: true });
     return true;
   }
+
+  if (request.type === "UPDATE_HISTORY") {
+    if (request.history && Array.isArray(request.history)) {
+      chrome.storage.local.set({ history: request.history }, () => {
+        if (chrome.runtime.lastError) {
+          console.error("Error saving updated history:", chrome.runtime.lastError);
+          sendResponse({ success: false, error: chrome.runtime.lastError.message });
+        } else {
+          sendResponse({ success: true });
+        }
+      });
+    } else {
+      sendResponse({ success: false, error: "Invalid history data provided." });
+    }
+    return true; // Asynchronous response
+  }
   
   if (request.type === "TEST_API_CONNECTION") {
     const { apiKey, apiEndpoint } = request;

--- a/options.html
+++ b/options.html
@@ -122,6 +122,12 @@
       <button id="save">保存设置</button>
       <button id="testConnection">测试API连接</button>
     </div>
+
+    <div class="button-group">
+      <button id="exportHistory" class="button">导出历史记录</button>
+      <button id="importHistory" class="button">导入历史记录</button>
+    </div>
+    <input type="file" id="importFile" accept=".json" style="display: none;">
     
     <div id="status" class="status"></div>
     

--- a/options.js
+++ b/options.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
   restoreOptions();
   document.getElementById('save').addEventListener('click', saveOptions);
   document.getElementById('testConnection').addEventListener('click', testApiConnection);
+  document.getElementById('exportHistory').addEventListener('click', exportHistoryData);
+  document.getElementById('importHistory').addEventListener('click', () => document.getElementById('importFile').click());
+  document.getElementById('importFile').addEventListener('change', handleFileUpload);
 });
 
 const defaultApiEndpoint = 'https://qianfan.baidubce.com/v2/';
@@ -28,6 +31,161 @@ function saveOptions() {
       status.textContent = '';
       status.className = 'status';
     }, 1500);
+  });
+}
+
+// 导出历史记录
+async function exportHistoryData() {
+  const status = document.getElementById('status');
+  status.textContent = '正在导出历史记录...';
+  status.className = 'status pending';
+
+  chrome.runtime.sendMessage({ type: "GET_HISTORY" }, (response) => {
+    if (chrome.runtime.lastError) {
+      console.error("Error sending message to background script:", chrome.runtime.lastError);
+      status.textContent = `导出失败: ${chrome.runtime.lastError.message || "未知错误"}`;
+      status.className = 'status error';
+      return;
+    }
+
+    if (response && response.history && response.history.length > 0) {
+      try {
+        const historyJson = JSON.stringify(response.history, null, 2);
+        const blob = new Blob([historyJson], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        const timestamp = new Date().toISOString().slice(0, 10);
+        a.download = `bainian_history_export_${timestamp}.json`;
+        document.body.appendChild(a); // Required for Firefox
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        status.textContent = '历史记录已成功导出！';
+        status.className = 'status success';
+      } catch (error) {
+        console.error("Error processing history for export:", error);
+        status.textContent = `导出失败: ${error.message || "处理数据时发生错误"}`;
+        status.className = 'status error';
+      }
+    } else {
+      status.textContent = '没有历史记录可以导出。';
+      status.className = 'status info'; // Using 'info' or a similar neutral class
+    }
+    setTimeout(() => {
+      status.textContent = '';
+      status.className = 'status';
+    }, 3000); // Clear status after 3 seconds
+  });
+}
+
+// 处理文件上传和导入
+async function handleFileUpload(event) {
+  const file = event.target.files[0];
+  const status = document.getElementById('status');
+
+  if (!file) {
+    return;
+  }
+
+  status.textContent = '正在导入历史记录...';
+  status.className = 'status pending';
+
+  const reader = new FileReader();
+  reader.onload = async (e) => {
+    try {
+      const importedHistory = JSON.parse(e.target.result);
+      if (!Array.isArray(importedHistory)) {
+        status.textContent = '导入失败：JSON文件内容不是有效的历史记录格式。';
+        status.className = 'status error';
+        event.target.value = null; // Reset file input
+        return;
+      }
+      await processImportedHistory(importedHistory);
+    } catch (error) {
+      status.textContent = '导入失败：文件格式错误或非JSON文件。';
+      status.className = 'status error';
+      console.error("Error parsing imported JSON:", error);
+    } finally {
+      event.target.value = null; // Reset file input
+      // Clear status message after a delay, handled within processImportedHistory or a dedicated function
+    }
+  };
+  reader.onerror = () => {
+    status.textContent = '导入失败：无法读取文件。';
+    status.className = 'status error';
+    event.target.value = null; // Reset file input
+  };
+  reader.readAsText(file);
+}
+
+async function processImportedHistory(importedHistory) {
+  const status = document.getElementById('status'); // Ensure status is accessible
+  status.textContent = '正在处理导入的数据...';
+  status.className = 'status pending';
+
+  chrome.runtime.sendMessage({ type: "GET_HISTORY" }, (response) => {
+    if (chrome.runtime.lastError) {
+      status.textContent = `导入失败：无法获取现有历史记录。 ${chrome.runtime.lastError.message}`;
+      status.className = 'status error';
+      console.error("Error getting history for import:", chrome.runtime.lastError);
+      setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+      return;
+    }
+
+    let currentHistory = response.history || [];
+    const existingWords = new Set(currentHistory.map(item => item.word));
+    let importedCount = 0;
+    let duplicateCount = 0;
+    const historyLimit = 1000;
+
+    // Iterate in reverse to add newer items from the file first, effectively making them older in the combined list
+    // if we unshift. Or iterate normally and unshift, which means items at top of file are newest.
+    // The user likely expects items at the top of their exported file to be the "latest" they exported,
+    // so unshifting them will place them as newest in the application.
+    for (const item of importedHistory) {
+      if (!item || typeof item.word !== 'string' || typeof item.translation !== 'string') {
+        console.warn("Skipping invalid item during import:", item);
+        continue; // Skip invalid items
+      }
+
+      if (existingWords.has(item.word)) {
+        duplicateCount++;
+      } else {
+        const newItem = {
+          word: item.word,
+          translation: item.translation,
+          timestamp: item.timestamp || new Date().toISOString(), // Use existing or new timestamp
+          repeatCount: item.repeatCount || 1,
+          timestamps: Array.isArray(item.timestamps) && item.timestamps.length > 0 
+                        ? item.timestamps 
+                        : [item.timestamp || new Date().toISOString()],
+          ef: item.ef || 2.5,
+          interval: item.interval || 0,
+          dueDate: item.dueDate || new Date().toISOString()
+        };
+        currentHistory.unshift(newItem); // Add to the beginning
+        existingWords.add(newItem.word); // Add to set to prevent duplicates from within the imported file itself if any
+        importedCount++;
+      }
+    }
+
+    currentHistory = currentHistory.slice(0, historyLimit); // Enforce history limit
+
+    chrome.runtime.sendMessage({ type: "UPDATE_HISTORY", history: currentHistory }, (updateResponse) => {
+      if (chrome.runtime.lastError) {
+        status.textContent = `导入失败：无法保存更新后的历史记录。 ${chrome.runtime.lastError.message}`;
+        status.className = 'status error';
+        console.error("Error updating history after import:", chrome.runtime.lastError);
+      } else if (updateResponse && updateResponse.success) {
+        status.textContent = `成功导入 ${importedCount} 条记录，${duplicateCount} 条重复记录被跳过。`;
+        status.className = 'status success';
+      } else {
+        status.textContent = `导入失败：${updateResponse.error || "未知错误"}`;
+        status.className = 'status error';
+      }
+      setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 5000); // Longer display for result
+    });
   });
 }
 


### PR DESCRIPTION
This commit introduces features to allow you to export your translation history to a JSON file and import history from a previously exported JSON file.

Key changes include:

- **options.html:**
    - Added "Export History" and "Import History" buttons to the settings page.
    - Added a hidden file input (`<input type="file">`) for JSON file selection during import.
- **options.js:**
    - Implemented `exportHistoryData` function: - Retrieves history from `background.js`. - Converts history to a formatted JSON string. - Triggers a browser download for the JSON file. - Displays status messages.
    - Implemented `handleFileUpload` and `processImportedHistory` functions for import:
        - Reads and parses the selected JSON file.
        - Validates JSON structure and individual history item integrity. - Communicates with `background.js` to get current history and to save merged history. - Handles duplicate entries by skipping them. - Enforces the history limit (1000 entries). - Displays status messages detailing imported and duplicate counts.
- **background.js:**
    - Added a new message listener for `UPDATE_HISTORY`.
    - This allows `options.js` to send the merged (imported) history data to be saved persistently in `chrome.storage.local`.

The import functionality ensures that duplicate entries are not added, and provides feedback to you on the outcome of the operation. The export functionality allows you to easily back up your translation history.