### PR TITLE
feat: Add JSON history editor and fix API test

### DIFF
--- a/background.js
+++ b/background.js
@@ -362,7 +362,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     (async () => {
       try {
         // 构建测试请求URL
-        const testRequestUrl = apiEndpoint || "https://qianfan.baidubce.com/v2/chat/completions";
+        const currentApiEndpoint = request.apiEndpoint || 'https://qianfan.baidubce.com/v2/';
+        const testRequestUrl = currentApiEndpoint.endsWith('/') ?
+            `${currentApiEndpoint}chat/completions` :
+            `${currentApiEndpoint}/chat/completions`;
         
         const testBody = {
           model: "ernie-4.5-turbo-32k",

--- a/options.html
+++ b/options.html
@@ -130,6 +130,23 @@
     <input type="file" id="importFile" accept=".json" style="display: none;">
     
     <div id="status" class="status"></div>
+
+    <hr style="margin-top: 30px; margin-bottom: 30px;">
+
+    <h3>历史记录 JSON 编辑器</h3>
+    <textarea id="jsonHistoryEditor" rows="15" style="width: calc(100% - 22px); margin-bottom: 10px;"></textarea>
+    
+    <div class="button-group">
+      <button id="loadHistoryToEditor" class="button">加载当前历史记录</button>
+      <button id="formatJsonInEditor" class="button">格式化JSON</button>
+      <button id="saveHistoryFromEditor" class="button">保存编辑器中的历史记录</button>
+    </div>
+
+    <div style="margin-top: 15px; display: flex; align-items: center;">
+      <label for="jsonSearchQuery" style="margin-right: 5px; font-weight: bold;">搜索:</label>
+      <input type="text" id="jsonSearchQuery" style="margin-right: 5px; width: auto; flex-grow: 1; margin-bottom: 0;">
+      <button id="searchJsonInEditor" class="button" style="margin-right: 0;">执行搜索</button>
+    </div>
     
     <div class="note">
       <strong>注意:</strong> 如果遇到"Failed to fetch"错误，请检查：

--- a/options.js
+++ b/options.js
@@ -7,6 +7,10 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('exportHistory').addEventListener('click', exportHistoryData);
   document.getElementById('importHistory').addEventListener('click', () => document.getElementById('importFile').click());
   document.getElementById('importFile').addEventListener('change', handleFileUpload);
+  document.getElementById('loadHistoryToEditor').addEventListener('click', loadHistoryToEditor);
+  document.getElementById('formatJsonInEditor').addEventListener('click', formatJsonInEditor);
+  document.getElementById('saveHistoryFromEditor').addEventListener('click', saveHistoryFromEditor);
+  document.getElementById('searchJsonInEditor').addEventListener('click', searchJsonInEditor);
 });
 
 const defaultApiEndpoint = 'https://qianfan.baidubce.com/v2/';
@@ -31,6 +35,212 @@ function saveOptions() {
       status.textContent = '';
       status.className = 'status';
     }, 1500);
+  });
+}
+
+// 搜索/过滤JSON编辑器中的内容
+function searchJsonInEditor() {
+  const editor = document.getElementById('jsonHistoryEditor');
+  const searchQueryInput = document.getElementById('jsonSearchQuery');
+  const status = document.getElementById('status');
+  
+  const query = searchQueryInput.value.trim().toLowerCase();
+  const jsonString = editor.value;
+
+  status.textContent = '正在搜索历史记录...';
+  status.className = 'status pending';
+
+  let historyArray;
+  try {
+    historyArray = JSON.parse(jsonString);
+  } catch (error) {
+    status.textContent = '编辑器中的JSON格式无效，无法搜索。';
+    status.className = 'status error';
+    console.error("Error parsing JSON for search:", error);
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  if (!Array.isArray(historyArray)) {
+    status.textContent = '编辑器内容不是有效的JSON数组，无法搜索。';
+    status.className = 'status error';
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  if (!query) {
+    // If query is empty, reformat the current content
+    editor.value = JSON.stringify(historyArray, null, 2);
+    status.textContent = '搜索词为空，已重新格式化编辑器内容。';
+    status.className = 'status info';
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  const filteredHistory = historyArray.filter(item => {
+    const wordMatch = typeof item.word === 'string' && item.word.toLowerCase().includes(query);
+    const translationMatch = typeof item.translation === 'string' && item.translation.toLowerCase().includes(query);
+    return wordMatch || translationMatch;
+  });
+
+  editor.value = JSON.stringify(filteredHistory, null, 2);
+
+  if (filteredHistory.length > 0) {
+    status.textContent = `找到了 ${filteredHistory.length} 条匹配记录。`;
+    status.className = 'status success';
+  } else {
+    status.textContent = '未找到匹配记录。';
+    status.className = 'status info';
+  }
+  setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+}
+
+
+// 保存编辑器中的历史记录
+async function saveHistoryFromEditor() {
+  const editor = document.getElementById('jsonHistoryEditor');
+  const status = document.getElementById('status');
+  const jsonString = editor.value;
+
+  status.textContent = '正在保存历史记录...';
+  status.className = 'status pending';
+
+  let newHistoryArray;
+  try {
+    newHistoryArray = JSON.parse(jsonString);
+  } catch (error) {
+    status.textContent = '无效的JSON格式，无法保存。请检查语法。';
+    status.className = 'status error';
+    console.error("Error parsing JSON from editor:", error);
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  if (!Array.isArray(newHistoryArray)) {
+    status.textContent = '顶层结构必须是JSON数组，无法保存。';
+    status.className = 'status error';
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  const validatedHistory = [];
+  for (let i = 0; i < newHistoryArray.length; i++) {
+    const item = newHistoryArray[i];
+    if (typeof item !== 'object' || item === null) {
+      status.textContent = `历史记录中的项目必须是对象，无法保存。第 ${i + 1} 项无效。`;
+      status.className = 'status error';
+      setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+      return;
+    }
+    if (typeof item.word !== 'string' || typeof item.translation !== 'string') {
+      status.textContent = `历史记录项目缺少'word'或'translation'，或类型不正确。无法保存。第 ${i + 1} 项无效。`;
+      status.className = 'status error';
+      setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+      return;
+    }
+    // Add default values for other critical fields if missing
+    validatedHistory.push({
+      word: item.word,
+      translation: item.translation,
+      timestamp: item.timestamp || new Date().toISOString(),
+      repeatCount: item.repeatCount || 1,
+      timestamps: Array.isArray(item.timestamps) && item.timestamps.length > 0 
+                    ? item.timestamps 
+                    : [item.timestamp || new Date().toISOString()],
+      ef: item.ef || 2.5,
+      interval: item.interval || 0,
+      dueDate: item.dueDate || new Date().toISOString()
+    });
+  }
+  
+  // Enforce history limit (optional, but good practice)
+  const historyLimit = 1000;
+  if (validatedHistory.length > historyLimit) {
+      status.textContent = `历史记录超过 ${historyLimit} 条上限，请删减后再保存。当前条数: ${validatedHistory.length}`;
+      status.className = 'status error';
+      setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 5000);
+      return;
+  }
+
+
+  chrome.runtime.sendMessage({ type: "UPDATE_HISTORY", history: validatedHistory }, (response) => {
+    if (chrome.runtime.lastError) {
+      status.textContent = `保存失败: ${chrome.runtime.lastError.message || "未知错误"}`;
+      status.className = 'status error';
+      console.error("Error saving history from editor (runtime.lastError):", chrome.runtime.lastError);
+    } else if (response && response.success) {
+      status.textContent = '历史记录已成功从编辑器保存。';
+      status.className = 'status success';
+    } else {
+      status.textContent = `保存失败: ${response ? response.error : "未知错误"}`;
+      status.className = 'status error';
+      console.error("Error saving history from editor (response.error):", response ? response.error : "No response");
+    }
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+  });
+}
+
+// 格式化JSON编辑器中的内容
+function formatJsonInEditor() {
+  const editor = document.getElementById('jsonHistoryEditor');
+  const status = document.getElementById('status');
+  const currentJson = editor.value;
+
+  if (!currentJson.trim()) {
+    status.textContent = '编辑器为空，无需格式化。';
+    status.className = 'status info';
+    setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+    return;
+  }
+
+  try {
+    const parsedJson = JSON.parse(currentJson);
+    editor.value = JSON.stringify(parsedJson, null, 2);
+    status.textContent = 'JSON已成功格式化。';
+    status.className = 'status success';
+  } catch (error) {
+    status.textContent = '无效的JSON格式，无法格式化。';
+    status.className = 'status error';
+    console.error("Error formatting JSON:", error);
+  }
+  setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 3000);
+}
+
+// 加载历史记录到JSON编辑器
+async function loadHistoryToEditor() {
+  const editor = document.getElementById('jsonHistoryEditor');
+  const status = document.getElementById('status');
+
+  status.textContent = '正在加载历史记录到编辑器...';
+  status.className = 'status pending';
+
+  chrome.runtime.sendMessage({ type: "GET_HISTORY" }, (response) => {
+    if (chrome.runtime.lastError) {
+      console.error("Error loading history to editor:", chrome.runtime.lastError);
+      editor.value = '加载历史记录失败。';
+      status.textContent = `加载失败: ${chrome.runtime.lastError.message || "未知错误"}`;
+      status.className = 'status error';
+    } else if (response && response.history) {
+      try {
+        const jsonString = JSON.stringify(response.history, null, 2);
+        editor.value = jsonString;
+        status.textContent = '历史记录已加载到编辑器。';
+        status.className = 'status success';
+      } catch (error) {
+        console.error("Error stringifying history for editor:", error);
+        editor.value = '格式化历史记录失败。';
+        status.textContent = `格式化失败: ${error.message || "处理数据时发生错误"}`;
+        status.className = 'status error';
+      }
+    } else {
+      editor.value = '[]'; // Show empty array if no history or unexpected response
+      status.textContent = '没有历史记录可加载，或加载失败。';
+      status.className = 'status info';
+    }
+    setTimeout(() => {
+      status.textContent = '';
+      status.className = 'status';
+    }, 3000);
   });
 }
 


### PR DESCRIPTION
This commit introduces two main changes:
1.  A fix for the "Test API Connection" functionality.
2.  A new JSON history editor in the options page.

**API Connection Test Fix:**
- The `TEST_API_CONNECTION` handler in `background.js` now correctly constructs the request URL by appending `/chat/completions` to your provided API endpoint, similar to the main translation logic. This resolves the 404 error that occurred when testing with base API URLs.

**JSON History Editor:**
- **UI Changes (`options.html`):**
    - Added a textarea (`jsonHistoryEditor`) for viewing and editing history data in JSON format.
    - Added buttons:
        - "Load Current History": Populates the textarea with current history.
        - "Format JSON": Pretty-prints the JSON in the textarea. - "Save History from Editor": Saves the content of the textarea to storage, overwriting current history. - "Execute Search": Filters the JSON in the textarea based on a query.
    - Added an input field (`jsonSearchQuery`) for search terms.
- **Functionality (`options.js`):**
    - **Load History:** Fetches history from `background.js` and displays it formatted in the editor.
    - **Format JSON:** Parses and pretty-prints the editor's content. Handles invalid JSON.
    - **Save History:**
        - Validates that the editor content is valid JSON and a valid array of history items (checking for `word`, `translation` fields, and adding defaults for other fields).
        - Enforces the 1000-entry history limit. - Sends the validated history to `background.js` to be saved.
    - **Search/Filter JSON:** - Filters the history items in the editor based on a case-insensitive search query matching `word` or `translation`. - Updates the editor with the filtered results. - Handles invalid JSON in the editor before searching.

I've planned thorough manual testing for all new functionalities and the API fix.